### PR TITLE
Fix a few things in getfileinfo

### DIFF
--- a/in_sidplay2/in_sidplay2.cpp
+++ b/in_sidplay2/in_sidplay2.cpp
@@ -360,11 +360,6 @@ void getfileinfo(const char *filename, char *title, int *length_in_ms)
 			return;
 		}
 		length = sidPlayer->GetSongLength();
-		if (length == -1)
-		{
-			ReleaseMutex(gMutex);
-			return;
-		}
 		subsongIndex = info->currentSong();//.currentSong;
 		strFilename.assign(info->path());
 		strFilename.append(info->dataFileName());
@@ -400,11 +395,6 @@ void getfileinfo(const char *filename, char *title, int *length_in_ms)
 		//tune.selectSong(info.startSong);
 		tune.selectSong(subsongIndex);
 		length = sidPlayer->GetSongLength(tune);
-		if (length == -1)
-		{
-			ReleaseMutex(gMutex);
-			return;
-		}
 	}
 	
 	//check if we got correct tune info
@@ -414,8 +404,8 @@ void getfileinfo(const char *filename, char *title, int *length_in_ms)
 		ReleaseMutex(gMutex);
 		return;
 	}
- 	length *= 1000;
 	if( length <0) length =0;
+	length *= 1000;
 	if(length_in_ms != NULL) *length_in_ms = length;
 	
 	/* build file title from template:


### PR DESCRIPTION
These commits fix a few issues with the `getfileinfo` function in Winamp 5 (haven't tested in Winamp 2  yet):

* Fixes the mutex deadlock when adding subsongs (issue #1)
* Fixes subsongs not always being added for one SID when opening multiple SIDs at once (fixed by attempting to add subsongs even when the provided filename is null/empty - seems to be a quirk with Winamp 5 for some reason)
* Fixes song info not being filled in if a song length wasn't available